### PR TITLE
Nueva variable para deregistration_delay

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -4,7 +4,7 @@ resource "aws_alb_target_group" "default" {
   port     = 80
   protocol = var.balancer["protocol"]
   vpc_id = data.aws_alb.this.0.vpc_id
-  deregistration_delay = 3
+  deregistration_delay = var.balancer_deregistration_delay
   target_type = var.network_mode != "awsvpc" ? var.target_type : "ip"
 
   dynamic "health_check" {

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,8 @@ variable "ordered_placement_strategies" {
     }
   ]
 }
+
+variable "balancer_deregistration_delay" {
+  description = "Target Group Deregistration delay"
+  default = 3
+}


### PR DESCRIPTION
Se agregó la variable balancer_deregistration_delay para el módulo. Tiene un valor por defecto de 3 y puede ser ajustado agregando la variable al modulo en terraform. 