### PR TITLE
Adding health_check_custom_config support

### DIFF
--- a/service_discovery.tf
+++ b/service_discovery.tf
@@ -14,6 +14,13 @@ resource "aws_service_discovery_service" "this" {
     routing_policy = "MULTIVALUE"
   }
 
+  dynamic "health_check_custom_config" {
+    for_each = var.service_discovery_failure_threshold == 0 ? [] : list(var.service_discovery_failure_threshold)
+    content {
+      failure_threshold = health_check_custom_config.value
+    }
+  }  
+  
 }
 
 resource "aws_security_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,8 @@ variable "balancer_deregistration_delay" {
   description = "Target Group Deregistration delay"
   default = 3
 }
+
+variable "service_discovery_failure_threshold" {
+  description = "Service discovery failure threshold"
+  default = 0
+}


### PR DESCRIPTION
It was added a new variable to enable a health check to the service discovery.  

New variable service_discovery_failure_threshold 