### PR TITLE
Support to health_check_custom_config

### DIFF
--- a/service_discovery.tf
+++ b/service_discovery.tf
@@ -15,7 +15,7 @@ resource "aws_service_discovery_service" "this" {
   }
 
   dynamic "health_check_custom_config" {
-    for_each = var.service_discovery_failure_threshold == 0 ? [] : list(var.service_discovery_failure_threshold)
+    for_each = lookup(var.discovery, "failure_threshold", "") == "" ? [] : list(var.discovery.failure_threshold)
     content {
       failure_threshold = health_check_custom_config.value
     }

--- a/service_discovery.tf
+++ b/service_discovery.tf
@@ -14,6 +14,13 @@ resource "aws_service_discovery_service" "this" {
     routing_policy = "MULTIVALUE"
   }
 
+  dynamic "health_check_custom_config" {
+    for_each = var.service_discovery_failure_threshold == 0 ? [] : list(var.service_discovery_failure_threshold)
+    content {
+      failure_threshold = health_check_custom_config.value
+    }
+  }  
+  
 }
 
 resource "aws_security_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,7 @@ variable "discovery" {
     dns_type = "A"
     routing_policy = "MULTIVALUE"     
     healthcheck_failure = 10
+    failure_threshold = 0
   }
 }
 
@@ -157,9 +158,4 @@ variable "ordered_placement_strategies" {
 variable "balancer_deregistration_delay" {
   description = "Target Group Deregistration delay"
   default = 3
-}
-
-variable "service_discovery_failure_threshold" {
-  description = "Service discovery failure threshold"
-  default = 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,8 @@ variable "balancer_deregistration_delay" {
   description = "Target Group Deregistration delay"
   default = 3
 }
+
+variable "service_discovery_failure_threshold" {
+  description = "Service discovery failure threshold"
+  default = 0
+}

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "discovery" {
     dns_type = "A"
     routing_policy = "MULTIVALUE"     
     healthcheck_failure = 10
-    failure_threshold = 0
+    failure_threshold = ""
   }
 }
 


### PR DESCRIPTION
It was added support to enable the health check on the service discovery. Using an integer value to the key failure_threshold on the variable map discovery.

  discovery = {
    namespace = var.app["cloud_map_namespace"]
    healthcheck_failure = 1
    dns_ttl = 10
    dns_type = "A"
    failure_threshold = 2
  }