### PR TITLE
Adding support to One Task Per Host placement strategy and Rolling update deployment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,33 @@ module "my_service" {
   
 }
 ```
+
+Example of One Task Per Host placement strategy and constrains
+```HCL
+module "my_service" {
+  source = "github.com/Aplyca/terraform-aws-ecsservice"
+  
+  # Others settings
+
+  ## One Task Per Host
+
+  placement_constraints = {
+    type  = "distinctInstance"
+    expression = ""
+  }
+
+  ordered_placement_strategies = []
+```
+
+Example of Rolling update deployment options
+```HCL
+module "my_service" {
+  source = "github.com/Aplyca/terraform-aws-ecsservice"
+  
+  # Others settings
+
+  ## Rolling update deployment options
+
+  deployment_maximum_percent = 100
+  deployment_minimum_healthy_percent = 50
+```

--- a/variables.tf
+++ b/variables.tf
@@ -159,3 +159,13 @@ variable "balancer_deregistration_delay" {
   description = "Target Group Deregistration delay"
   default = 3
 }
+
+variable "deployment_maximum_percent" {
+  description = "deployment_maximum_percent"
+  default = null
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "deployment_minimum_healthy_percent"
+  default = null
+}


### PR DESCRIPTION
It was added the variables deployment_maximum_percent and deployment_minimum_healthy_percent to change Rolling update deployment options.

Added a fix to support no strategies in ordered_placement_strategies.

Added placement_constraints in the ecs service instead of the task definition. 
