### PR TITLE
Adding alb cognito autentication support

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -34,9 +34,23 @@ resource "aws_lb_listener_rule" "this" {
   count = length(var.listener_rules)  
   listener_arn =  element(data.aws_alb_listener.this, count.index).arn
 
-  action {
-    type = "forward"
-    target_group_arn = aws_alb_target_group.default.0.arn
+  dynamic "action" {
+    for_each = var.aws_lb_listener_rule_actions
+
+    content {
+      type = action.value.type
+      target_group_arn = lookup(action.value, "type", null) == "forward" ? aws_alb_target_group.default.0.arn : "" 
+
+      dynamic "authenticate_cognito" {
+        for_each = lookup(action.value, "type", null) == "authenticate-cognito" ? list(action.value.type) :[]
+        content {
+          user_pool_arn = action.value.user_pool_arn
+          user_pool_client_id = action.value.user_pool_client_id
+          user_pool_domain    = action.value.user_pool_domain
+        }
+      }
+
+    }
   }
 
   condition {

--- a/variables.tf
+++ b/variables.tf
@@ -169,3 +169,13 @@ variable "deployment_minimum_healthy_percent" {
   description = "deployment_minimum_healthy_percent"
   default = null
 }
+
+variable "aws_lb_listener_rule_actions" {
+  description = "aws lb listener rule actions"
+  type = list
+  default = [
+    {
+      type = "forward"
+    }
+  ]
+}


### PR DESCRIPTION
Example of use:

  aws_lb_listener_rule_actions = [
    {
      type = "authenticate-cognito"
      user_pool_arn = "arn:aws:cognito-idp:us-east-1:266144297920:userpool/us-east-1_5GGyzdFns"
      user_pool_client_id = "1l19kevo3c4nlm247rqi6gu7t2"
      user_pool_domain    = "ccb-basic-auth"
    },
    {
      type = "forward"
    }
  ]